### PR TITLE
Use built-in bookmarks feed parameter

### DIFF
--- a/layouts/shortcodes/bookmarks.html
+++ b/layouts/shortcodes/bookmarks.html
@@ -1,5 +1,5 @@
 {{ $template := resources.Get "templates/bookmarks-shortcode-default-template.html" }}
-{{ $feed_url := $.Site.Params.bookmarks_shortcode_feed_url }}
+{{ $feed_url := $.Site.Params.feeds.bookmarks_json }}
 {{ $response := getJSON $feed_url }}
 
 {{ if isset $response "items" }}

--- a/plugin.json
+++ b/plugin.json
@@ -1,12 +1,5 @@
 {
-  "version": "0.9.0",
+  "version": "0.9.1",
   "title": "Bookmarks Shortcode",
-  "description": "Share your bookmarks with the world.",
-  "fields": [
-    {
-      "field": "params.bookmarks_shortcode_feed_url",
-      "label": "JSON Feed URL",
-      "placeholder": "https://micro.blog/feeds/yourname/bookmarks/decc3dfad46628dc2cac.json"
-    }
-  ]
+  "description": "Share your bookmarks with the world."
 }


### PR DESCRIPTION
Hi @svendahlstrand, I'm experimenting with adding some feed URLs as built-in parameters that plug-ins can access. I'm starting with the bookmarks JSON feed.

This pull request just changes your shortcode to use the built-in parameter, so no copy/paste settings configuration is necessary.

Lemme know if you have any thoughts. My only concern is that some feed URLs like this are kind of private-ish, but I think the user intent of installing the plug-in should be enough to give access to the setting. (Also relates to the other discussion about auto-installing plug-ins… Which maybe should be avoided after all.)